### PR TITLE
Fix file references and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Crypto Trading System
+
+This repository contains a simple HTML/JavaScript interface for a crypto trading system demo.
+
+## Local setup
+
+1. Clone the repository:
+   ```bash
+   git clone <REPO-URL>
+   cd cryptoClaude
+   ```
+2. Start a basic HTTP server (Python 3 is preinstalled on most systems):
+   ```bash
+   python3 -m http.server 8080
+   ```
+   Then open your browser to `http://localhost:8080/index.html`.
+   Alternatively you can open `index.html` directly in your browser, but using an HTTP server avoids CORS issues.
+
+## File overview
+
+- `index.html` – main page that loads `style.css` and `crypto-trading-complete.js`.
+- `style.css` – styles for the application.
+- `crypto-trading-complete.js` – JavaScript logic including wallet and trading functionality.
+
+Ensure the file names match as above. The previous file `app.js` is replaced by `crypto-trading-complete.js` in the HTML.
+

--- a/index.html
+++ b/index.html
@@ -473,6 +473,6 @@
     <div class="toast-container" id="toastContainer"></div>
 
     <!-- Load the application -->
-    <script src="app.js"></script>
+    <script src="crypto-trading-complete.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename `index-html-updated.html` to `index.html`
- load `crypto-trading-complete.js` instead of missing `app.js`
- document local setup and usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6878c752c6208320a27ebab6b71e8727